### PR TITLE
Update lower bound of zend-text library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "zendframework/zend-text": "~2.5"
+        "zendframework/zend-text": "^2.0.3"
     }
 }


### PR DESCRIPTION
The library will work with earlier versions of zend-text allowing compatibility with projects locked to older versions of zend framework