### PR TITLE
Added PHP 8.2 support, dropped PHP 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr-4": {"MathieuViossat\\Util\\": "src/"}
     },
     "require": {
-        "php": ">=5.3.0",
-        "laminas/laminas-text": "^2.9"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "laminas/laminas-text": "^2.10"
     }
 }


### PR DESCRIPTION
The new release of [laminas-text 2.10.0](https://github.com/laminas/laminas-text/releases/tag/2.10.0) dropped support for php < 8 version.