### PR TITLE
Fix the correct php dependency in composer file based on laminas-text.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr-4": {"MathieuViossat\\Util\\": "src/"}
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-text": "^2.9"
     }
 }


### PR DESCRIPTION
Since release [2.8 from laminas-text](https://github.com/laminas/laminas-text/blob/2.8.x/composer.json) dropped support for php 5, we update the composer file to reflects the same dependency of [laminas-text ^2.9](https://github.com/laminas/laminas-text/blob/2.9.x/composer.json).

I suggest to generate a minor release with this change.